### PR TITLE
ntfy needs to be publicly exposed to properly work

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -32,44 +32,46 @@ ram.build = "50M"
 ram.runtime = "50M"
 
 [install]
-    [install.domain]
-    type = "domain"
+[install.domain]
+type = "domain"
 
-    [install.init_main_permission]
-    type = "group"
-    default = "visitors"
+[install.init_main_permission]
+type = "group"
+default = "visitors"
 
-    [install.admin]
-    type = "user"
+[install.admin]
+type = "user"
 
-    [install.password]
-    type = "password"
+[install.password]
+type = "password"
 
 [resources]
-    [resources.sources]
-        [resources.sources.main]
-        autoupdate.strategy = "latest_github_release"
+[resources.sources]
+[resources.sources.main]
+autoupdate.strategy = "latest_github_release"
 
-        autoupdate.asset.amd64 = '.*_linux_amd64\.tar\.gz'
-        autoupdate.asset.arm64 = '.*_linux_arm64\.tar\.gz'
-        autoupdate.asset.armhf = '.*_linux_armv7\.tar\.gz'
+autoupdate.asset.amd64 = '.*_linux_amd64\.tar\.gz'
+autoupdate.asset.arm64 = '.*_linux_arm64\.tar\.gz'
+autoupdate.asset.armhf = '.*_linux_armv7\.tar\.gz'
 
-        amd64.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_amd64.tar.gz"
-        amd64.sha256 = "7158312a9f6e49daf94355e63a8fa73e04f3c2d5defc2bba0cbf3e35fdf7bf9a"
+amd64.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_amd64.tar.gz"
+amd64.sha256 = "7158312a9f6e49daf94355e63a8fa73e04f3c2d5defc2bba0cbf3e35fdf7bf9a"
 
-        arm64.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_arm64.tar.gz"
-        arm64.sha256 = "918d0a81355288ef60e8ef0d0587630f069c5c75909a12d6abbdb2e1628dbc52"
+arm64.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_arm64.tar.gz"
+arm64.sha256 = "918d0a81355288ef60e8ef0d0587630f069c5c75909a12d6abbdb2e1628dbc52"
 
-        armhf.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_armv7.tar.gz"
-        armhf.sha256 ="bf63f969b64889158bb0daa2f55f2e3356516a0c4ff2f57d0392a0c7df0abefc"
+armhf.url = "https://github.com/binwiederhier/ntfy/releases/download/v2.8.0/ntfy_2.8.0_linux_armv7.tar.gz"
+armhf.sha256 = "bf63f969b64889158bb0daa2f55f2e3356516a0c4ff2f57d0392a0c7df0abefc"
 
-    [resources.system_user]
+[resources.system_user]
 
-    [resources.install_dir]
+[resources.install_dir]
 
-    [resources.permissions]
-    main.url = "/"
-    main.auth_header = false
+[resources.permissions]
+main.url = "/"
+main.auth_header = false
+main.protected = true
+main.allowed = "visitors"
 
-    [resources.ports]
-    main.default = 8080
+[resources.ports]
+main.default = 8080

--- a/tests.toml
+++ b/tests.toml
@@ -1,6 +1,9 @@
 test_format = 1.0
 
+# ntfy needs to be publicly exposed to properly work, see #34 
+exclude = "install.private"
+
 [default]
-    test_upgrade_from.727dfd9.name = "Upgrade from 2.6.2~ynh1"
-    test_upgrade_from.e89c0fb.name = "Upgrade from 2.5.0~ynh1"
-    #test_upgrade_from.5b729db.name = "Upgrade from 2.4.0~ynh1"
+test_upgrade_from.727dfd9.name = "Upgrade from 2.6.2~ynh1"
+test_upgrade_from.e89c0fb.name = "Upgrade from 2.5.0~ynh1"
+#test_upgrade_from.5b729db.name = "Upgrade from 2.4.0~ynh1"


### PR DESCRIPTION
## Problem

ntfy needs to be exposed to properly work
see: https://forum.yunohost.org/t/question-how-to-ntfy-service/25990/6?u=oniricorpe
see: https://docs.ntfy.sh/subscribe/api/

## Solution

mandatory `/` exposure to visitors

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
